### PR TITLE
attach bastion security group based on product domain

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,8 @@
+data "aws_security_group" "bastion" {
+  filter {
+    name   = "group-name"
+    values = ["${var.product_domain}bstn-mongod"]
+  }
+
+  vpc_id = "vpc-32b41f57"
+}

--- a/examples/master/main.tf
+++ b/examples/master/main.tf
@@ -28,13 +28,13 @@ module "txtbook_postgres" {
   environment    = "production"
   description    = "Postgres to store Tesla Extranet booking data"
 
-  instance_class = "db.t2.small"
-  engine_version = "9.6.6"
+  instance_class    = "db.t2.small"
+  engine_version    = "9.6.6"
   allocated_storage = 20
 
   # Change to valid security group id
   vpc_security_group_ids = [
-    "sg-50036436"
+    "sg-50036436",
   ]
 
   # Change to valid db subnet group nam

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ locals {
 
   db_identifier_suffix_max_byte_length = "${(local.db_identifier_max_length - length(local.db_identifier_prefix)) / 2}"
   db_identifier_suffix_byte_length     = "${min(local.max_byte_length, local.db_identifier_suffix_max_byte_length)}"
-
-  final_snapshot_identifier = "${random_id.db_identifier.hex}-final-snapshot"
+  db_bastion_security_group            = ["${data.aws_security_group.bastion.id}"]
+  final_snapshot_identifier            = "${random_id.db_identifier.hex}-final-snapshot"
 
   # Change default values for read replica instance
   is_read_replica         = "${var.replicate_source_db == "" ? false : true}"
@@ -51,13 +51,12 @@ resource "aws_db_instance" "this" {
   password       = "${local.password}"
   port           = "${var.port}"
 
-  allocated_storage = "${var.allocated_storage}"
-  storage_type      = "${var.storage_type}"
-  iops              = "${var.iops}"
-  storage_encrypted = "${var.storage_encrypted}"
-  kms_key_id        = "${var.kms_key_id}"
-
-  vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
+  allocated_storage      = "${var.allocated_storage}"
+  storage_type           = "${var.storage_type}"
+  iops                   = "${var.iops}"
+  storage_encrypted      = "${var.storage_encrypted}"
+  kms_key_id             = "${var.kms_key_id}"
+  vpc_security_group_ids = ["${concat(var.vpc_security_group_ids,local.db_bastion_security_group)}"]
   multi_az               = "${local.multi_az}"
   publicly_accessible    = false
 


### PR DESCRIPTION
Since we have db bastion to troubleshoot and security group for db bastion already created for each product domain, it's affect new infra creation because sometime we forget to attach bastion security group