### PR TITLE
create new required variable for attach bastion security group

### DIFF
--- a/examples/master/main.tf
+++ b/examples/master/main.tf
@@ -28,13 +28,13 @@ module "txtbook_postgres" {
   environment    = "production"
   description    = "Postgres to store Tesla Extranet booking data"
 
-  instance_class = "db.t2.small"
-  engine_version = "9.6.6"
+  instance_class    = "db.t2.small"
+  engine_version    = "9.6.6"
   allocated_storage = 20
 
   # Change to valid security group id
   vpc_security_group_ids = [
-    "sg-50036436"
+    "sg-50036436",
   ]
 
   # Change to valid db subnet group nam

--- a/main.tf
+++ b/main.tf
@@ -57,9 +57,13 @@ resource "aws_db_instance" "this" {
   storage_encrypted = "${var.storage_encrypted}"
   kms_key_id        = "${var.kms_key_id}"
 
-  vpc_security_group_ids = ["${concat(var.vpc_security_group_ids,list(var.bastion_security_group_id))}"]
-  multi_az               = "${local.multi_az}"
-  publicly_accessible    = false
+  vpc_security_group_ids = [
+    "${var.vpc_security_group_ids}",
+    "${var.bastion_security_group_id}",
+  ]
+
+  multi_az            = "${local.multi_az}"
+  publicly_accessible = false
 
   db_subnet_group_name = "${var.db_subnet_group_name}"
   parameter_group_name = "${var.parameter_group_name}"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_db_instance" "this" {
   storage_encrypted = "${var.storage_encrypted}"
   kms_key_id        = "${var.kms_key_id}"
 
-  vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
+  vpc_security_group_ids = ["${concat(var.vpc_security_group_ids,list(var.bastion_security_group_id))}"]
   multi_az               = "${local.multi_az}"
   publicly_accessible    = false
 

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,11 @@ variable "vpc_security_group_ids" {
   description = "List of VPC security groups to associate"
 }
 
+variable "bastion_security_group_id" {
+  type        = "string"
+  description = "bastion security groups to associate"
+}
+
 variable "db_subnet_group_name" {
   type        = "string"
   description = "Name of DB subnet group"


### PR DESCRIPTION
When we provision new infra especially rds we forget to attach bastion security group , so to reduce potential incident we add new required variable