### PR TITLE
 Add Support to Enable Performance Insights

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "aws_db_instance" "this" {
   monitoring_interval = "${var.monitoring_interval}"
   monitoring_role_arn = "${var.monitoring_role_arn}"
 
-  performance_insights_enabled = "${var.performance_insights}"
+  performance_insights_enabled = "${var.performance_insights_enabled}"
 
   tags = {
     Name          = "${random_id.db_identifier.hex}"

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,8 @@ resource "aws_db_instance" "this" {
   monitoring_interval = "${var.monitoring_interval}"
   monitoring_role_arn = "${var.monitoring_role_arn}"
 
+  performance_insights_enabled = "${var.performance_insights}"
+
   tags = {
     Name          = "${random_id.db_identifier.hex}"
     Service       = "${var.service_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -168,7 +168,7 @@ variable "monitoring_interval" {
   default     = "60"
 }
 
-variable "performance_insights" {
+variable "performance_insights_enabled" {
   type        = "string"
   description = "The values which defines if the performance insights for this db will be enabled or not"
   default     = "false"

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,12 @@ variable "monitoring_interval" {
   default     = "60"
 }
 
+variable "performance_insights" {
+  type        = "string"
+  description = "The values which defines if the performance insights for this db will be enabled or not"
+  default     = "false"
+}
+
 variable "monitoring_role_arn" {
   type        = "string"
   description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs"


### PR DESCRIPTION
### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #13 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-rds-postgres/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note

FEATURES:

* performance insights are now available to configure
* the default value for performance insights is `false`ENHANCEMENTS:
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + aws_db_instance.this
      id:                                    <computed>
      address:                               <computed>
      allocated_storage:                     "20"
      allow_major_version_upgrade:           "false"
      apply_immediately:                     "false"
      arn:                                   <computed>
      auto_minor_version_upgrade:            "false"
      availability_zone:                     <computed>
      backup_retention_period:               "7"
      backup_window:                         <computed>
      ca_cert_identifier:                    <computed>
      character_set_name:                    <computed>
      copy_tags_to_snapshot:                 "true"
      db_subnet_group_name:                  <computed>
      endpoint:                              <computed>
      engine:                                "postgres"
      engine_version:                        <computed>
      final_snapshot_identifier:             "${local.final_snapshot_identifier}"
      hosted_zone_id:                        <computed>
      identifier:                            "${random_id.db_identifier.hex}"
      identifier_prefix:                     <computed>
      instance_class:                        "db.t2.micro"
      iops:                                  "0"
      kms_key_id:                            <computed>
      license_model:                         <computed>
      maintenance_window:                    "mon:00:00-mon:03:00"
      monitoring_interval:                   "60"
      monitoring_role_arn:                   "arn:aws:iam::123456789012:role/S3Access"
      multi_az:                              "true"
      name:                                  <computed>
      option_group_name:                     <computed>
      parameter_group_name:                  "groupName"
      password:                              <sensitive>
      performance_insights_enabled:          "false"
      performance_insights_kms_key_id:       <computed>
      performance_insights_retention_period: <computed>
      port:                                  "5432"
      publicly_accessible:                   "false"
      replicas.#:                            <computed>
      resource_id:                           <computed>
      skip_final_snapshot:                   "false"
      status:                                <computed>
      storage_encrypted:                     "true"
      storage_type:                          "gp2"
      tags.%:                                <computed>
      timezone:                              <computed>
      username:                              "postgres"
      vpc_security_group_ids.#:              "1"
      vpc_security_group_ids.809200604:      "sg-ca3d48a2"

  + random_id.db_identifier
      id:                                    <computed>
      b64:                                   <computed>
      b64_std:                               <computed>
      b64_url:                               <computed>
      byte_length:                           "8"
      dec:                                   <computed>
      hex:                                   <computed>
      prefix:                                "someService-postgres-"

  + random_id.password
      id:                                    <computed>
      b64:                                   <computed>
      b64_std:                               <computed>
      b64_url:                               <computed>
      byte_length:                           "8"
      dec:                                   <computed>
      hex:                                   <computed>


Plan: 3 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
