### PR TITLE
Add deletion protection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ resource "aws_db_instance" "this" {
   auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
   apply_immediately           = "${var.apply_immediately}"
   maintenance_window          = "${var.maintenance_window}"
+  deletion_protection         = "${var.deletion_protection}"
 
   backup_retention_period = "${local.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/variables.tf
+++ b/variables.tf
@@ -179,6 +179,12 @@ variable "monitoring_role_arn" {
   description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs"
 }
 
+variable "deletion_protection" {
+  type        = "string"
+  description = "If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true. The default is false"
+  default     = false
+}
+
 variable "ca_cert_identifier" {
   type        = "string"
   description = "Specifies the identifier of the CA certificate for the DB instance"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #17 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-rds-postgres/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* Added a variable to control deletion protection for the rds instance. The default value is `false`.
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan
Terraform will perform the following actions:

  ~ module.this.module.rds_cluster.aws_db_instance.this
      deletion_protection: "false" => "true"

Plan: 0 to add, 1 to change, 0 to destroy.
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
