### PR TITLE
add option to enable storage autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ No requirements.
 | iops | The amount of provisioned IOPS. Setting this implies a storage\_type of io1 | `string` | `"0"` | no |
 | kms\_key\_id | Specifies a custom KMS key to be used to encrypt | `string` | `""` | no |
 | maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' | `string` | n/a | yes |
+| max_allocated\_storage | The upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Set this value to be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling. | `string` | `"0"` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance | `string` | `"60"` | no |
 | monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `string` | n/a | yes |
 | multi\_az | Specifies if the RDS instance is multi-AZ | `string` | `"true"` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,11 +64,12 @@ resource "aws_db_instance" "this" {
   port               = var.port
   ca_cert_identifier = var.ca_cert_identifier
 
-  allocated_storage = var.allocated_storage
-  storage_type      = var.storage_type
-  iops              = var.iops
-  storage_encrypted = var.storage_encrypted
-  kms_key_id        = var.kms_key_id
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_type          = var.storage_type
+  iops                  = var.iops
+  storage_encrypted     = var.storage_encrypted
+  kms_key_id            = var.kms_key_id
 
   vpc_security_group_ids = flatten([
     var.vpc_security_group_ids,

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "allocated_storage" {
   description = "The allocated storage in gigabytes. For read replica, set the same value as master's"
 }
 
+variable "max_allocated_storage" {
+  type        = string
+  description = "The upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Set this value to be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling."
+  default     = "0"
+}
+
 variable "storage_type" {
   type        = string
   description = "One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD)"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #34 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-rds-postgres/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* feature: Add support to enable storage autoscaling

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
