### PR TITLE
enable option group name as a variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,7 @@ resource "aws_db_instance" "this" {
 
   db_subnet_group_name = var.db_subnet_group_name
   parameter_group_name = var.parameter_group_name
+  option_group_name    = var.option_group_name
 
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade

--- a/variables.tf
+++ b/variables.tf
@@ -103,6 +103,11 @@ variable "parameter_group_name" {
   description = "Name of the DB parameter group to associate"
 }
 
+variable "option_group_name" {
+  type        = string
+  description = "Name of the DB option group to associate"
+}
+
 variable "availability_zone" {
   type        = string
   description = "The AZ for the RDS instance. It is recommended to only use this when creating a read replica instance"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-rds-postgres/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Any Notes regarding your submitted PR, like breaking changes or else.

FEATURES:


ENHANCEMENTS:

* Enable option_group_name through variable

BUG FIXES:

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
