### PR TITLE
add option to enable exporting log to cloudwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ No requirements.
 | storage\_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD) | `string` | `"gp2"` | no |
 | username | Username for the master DB user | `string` | `"postgres"` | no |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | `list` | n/a | yes |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs | `list` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,8 @@ resource "aws_db_instance" "this" {
 
   performance_insights_enabled = var.performance_insights_enabled
 
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+
   tags = merge(var.additional_tags, local.default_tags)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -203,3 +203,8 @@ variable "additional_tags" {
   description = "The additional aws_db_instance tags that will be merged over the default tags"
 }
 
+variable "enabled_cloudwatch_logs_exports" {
+  type        = list(string)
+  default     = []
+  description = "List of log types to enable for exporting to CloudWatch logs"
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #7

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-rds-postgres/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* feature: add option to enable exporting log to cloudwatch log
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
